### PR TITLE
Add public decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ pip install auto-all
 
 ## Usage
 
+There are two main approaches:
+
+      1) Use `start_all` and `end_all` to wrap all public functions and
+         variables.
+      2) Use the `@public` decorator to identify publicly facing functions.
+
+### start_all/end_all approach
+
 First, import the auto_all functions into your module.
 
 ```python
@@ -56,11 +64,10 @@ def a_private_function():
 ```
 
 Now we are ready to start defining public functions, so we use
-`start_all()`.  We need to pass it the globals dict so that it can
-see what's already defined.
+`start_all()`.
 
 ```python
-start_all(globals())
+start_all()
 ```
 
 Now we can define our public functions.
@@ -74,7 +81,7 @@ Finally we use `end_all()` to finish defining public functions and
 create the `__all__` variable.
 
 ```python
-end_all(globals())
+end_all()
 ```
 
 When we look at the `__all__` variable we can see only the public
@@ -95,10 +102,112 @@ from pathlib import Path
 def a_private_function():
     print("This is a private function.")
 
-start_all(globals())
+start_all()
 
 def a_public_function():
     print("This is a public function.")
 
+end_all()
+```
+
+It is possible to pass the globals dict to the `start_all` and
+`end_all` function calls. This is not typically necessary, and is
+only included for backward compatibility.
+
+```python
+start_all(globals())
+
+def another_public_function():
+    pass
+
 end_all(globals())
+
+def a_private_function():
+    pass
+
+print(__all__)
+```
+
+### `@public` decorator approach
+
+The second approach is to use the `@public` decorator. Note that this
+approach is only suitable for functions, and will not work for declaring
+classes or variables as public.
+
+First, import the decorator:
+
+```python
+from auto_all import public
+```
+
+We can define any private functions without any decorator:
+
+```python
+def a_private_function():
+    pass
+```
+
+We can define public functions by decorating with the `@public`
+decorator:
+
+```python
+@public
+def a_public_function():
+    pass
+```
+
+The `__all__` variable will only include functions that have been
+declared as public:
+
+```
+>>> print(__all__)
+['a_public_function']
+```
+
+Combining the two approaches
+============================
+
+In the event that you need to declare variables and classes as public, and
+also want to make use of the `@public` decorator for functions you can
+combine both methods.
+
+Private variables can be defined outside the start/end block:
+
+```python
+PRIVATE_VARIABLE = "I am private"
+```
+
+Public items can be defined between the `start_all()` and `end_all()`
+function calls:
+
+```python
+start_all()
+PUBLIC_VARIABLE = "I am public"
+class PublicClass:
+    pass
+end_all()
+```
+
+Private functions can be defined undecorated outside the start/end block:
+
+```python
+def private_function():
+pass
+```
+
+Public functions can be decorated with the `@public` decorator:
+
+```python
+@public
+def public_function():
+    pass
+```
+
+The `__all__` variable will include any object declared between the
+`start_all` and `end_all` calls, and any function decorated with the
+`@public` decorator:
+
+```
+>>> print(__all__)
+['PUBLIC_VARIABLE', 'PublicClass', 'public_function']
 ```


### PR DESCRIPTION
Add the @public decorator, which can be used to decorate
functions, marking them as public and adding them to the
__all__ list.

Include doctests and documentation.

Also includes documentation updates to the README.md for
the previous change which made globs optional for start_all
and end_all functions.